### PR TITLE
Really fix whitespace bugs in jsoniter

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -62,7 +62,7 @@ type Decoder struct {
 
 // Decode decode JSON into interface{}
 func (adapter *Decoder) Decode(obj interface{}) error {
-	adapter.iter.skipWhitespacesWithoutLoadMore()
+	adapter.iter.skipWhitespace()
 	if adapter.iter.head == adapter.iter.tail && adapter.iter.reader != nil {
 		if !adapter.iter.loadMore() {
 			return io.EOF

--- a/api_tests/decoder_test.go
+++ b/api_tests/decoder_test.go
@@ -3,12 +3,11 @@ package test
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"testing"
-
-	jsoniter "github.com/json-iterator/go"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_disallowUnknownFields(t *testing.T) {

--- a/iter.go
+++ b/iter.go
@@ -153,20 +153,6 @@ func (iter *Iterator) WhatIsNext() ValueType {
 	return valueType
 }
 
-func (iter *Iterator) skipWhitespacesWithoutLoadMore() bool {
-	for i := iter.head; i < iter.tail; i++ {
-		c := iter.buf[i]
-		switch c {
-		case ' ', '\n', '\t', '\r':
-			continue
-		}
-		iter.head = i
-		return false
-	}
-	iter.head = iter.tail
-	return true
-}
-
 func (iter *Iterator) isObjectEnd() bool {
 	c := iter.nextToken()
 	if c == ',' {
@@ -193,6 +179,24 @@ func (iter *Iterator) nextToken() byte {
 		}
 		if !iter.loadMore() {
 			return 0
+		}
+	}
+}
+
+func (iter *Iterator) skipWhitespace() {
+	for {
+		for i := iter.head; i < iter.tail; i++ {
+			c := iter.buf[i]
+			switch c {
+			case ' ', '\n', '\t', '\r':
+				continue
+			}
+			iter.head = i
+			return
+		}
+		if !iter.loadMore() {
+			iter.head = iter.tail
+			return
 		}
 	}
 }
@@ -275,9 +279,7 @@ func (iter *Iterator) loadMore() bool {
 		} else {
 			iter.head = 0
 			iter.tail = n
-			if !iter.skipWhitespacesWithoutLoadMore() {
-				return true
-			}
+			return true
 		}
 	}
 }

--- a/iter_object.go
+++ b/iter_object.go
@@ -234,34 +234,3 @@ func (iter *Iterator) readObjectStart() bool {
 	iter.ReportError("readObjectStart", "expect { or n, but found "+string([]byte{c}))
 	return false
 }
-
-func (iter *Iterator) readObjectFieldAsBytes() (ret []byte) {
-	str := iter.ReadStringAsSlice()
-	if iter.skipWhitespacesWithoutLoadMore() {
-		if ret == nil {
-			ret = make([]byte, len(str))
-			copy(ret, str)
-		}
-		if !iter.loadMore() {
-			return
-		}
-	}
-	if iter.buf[iter.head] != ':' {
-		iter.ReportError("readObjectFieldAsBytes", "expect : after object field, but found "+string([]byte{iter.buf[iter.head]}))
-		return
-	}
-	iter.head++
-	if iter.skipWhitespacesWithoutLoadMore() {
-		if ret == nil {
-			ret = make([]byte, len(str))
-			copy(ret, str)
-		}
-		if !iter.loadMore() {
-			return
-		}
-	}
-	if ret == nil {
-		return str
-	}
-	return ret
-}


### PR DESCRIPTION
In #1 I tried (but failed) to fix whitespace bugs in the jsoniter `Decode` call.  That PR actually broke all kinds of stuff that isn't caught by existing unittests.

In this PR I'm undoing those changes, and fixing things the right way.  I've added a new unittest that demonstrates the bug (that fails before #1), and succeeds now.

Note that I've removed both `readObjectFieldAsBytes` and `skipWhitespacesWithoutLoadMore` because they aren't actually used, and are confusing and buggy.